### PR TITLE
fix form_for location

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,8 +5,8 @@
 
           <div class="register-register-container">
 
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <fieldset class="register-input-container">
-          <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
             <%= devise_error_messages! %>
 
             <div class="label"><%= f.label :email %><br />


### PR DESCRIPTION
## WHY
新規登録画面で、Submitボタンが動作しないため

## WHAT
`<%= form_for %>` タグがHTMLタグ `<fieldset>` のスコープを跨いで記述されていたため、HTMLポリシーに反していた。そこで、2つの `<fieldset>` を包含できる位置に移動した。